### PR TITLE
Prevent unresponsive trackpad after revoking Accessibility permission

### DIFF
--- a/MiddleClick/Controller.m
+++ b/MiddleClick/Controller.m
@@ -164,7 +164,7 @@ static void unregisterTouchCallback()
     // create eventTap which listens for core grpahic events with the filter
     // sepcified above (so left mouse down and up again)
     CFMachPortRef eventTap = CGEventTapCreate(
-                                              kCGHIDEventTap, kCGHeadInsertEventTap, kCGEventTapOptionDefault,
+                                              kCGHIDEventTap, kCGHeadInsertEventTap, kCGEventTapOptionListenOnly,
                                               eventMask, mouseCallback, NULL);
     currentEventTap = eventTap;
 

--- a/MiddleClick/TrayMenu.m
+++ b/MiddleClick/TrayMenu.m
@@ -14,7 +14,8 @@
 
 - (void)initAccessibilityPermissionStatus:(NSMenu*)menu
 {
-  BOOL hasAccessibilityPermission = AXIsProcessTrusted();
+  NSDictionary *options = @{(id)kAXTrustedCheckOptionPrompt: @YES};
+  BOOL hasAccessibilityPermission = AXIsProcessTrustedWithOptions((CFDictionaryRef)options);
 
   [self updateAccessibilityPermissionStatus:menu
                  hasAccessibilityPermission:hasAccessibilityPermission];


### PR DESCRIPTION
- Use `AXIsProcessTrustedWithOptions` instead of `AXIsProcessTrusted`
- Use event tap option `.listenOnly` instead of `.default`

closes #63