### PR TITLE
Closes #75: Fix multiuser double-middle-click

### DIFF
--- a/MiddleClick/Controller.m
+++ b/MiddleClick/Controller.m
@@ -248,11 +248,15 @@ static void unregisterMouseCallback(void)
   stopUnstableListeners();
 }
 
-/// Callback for user login. This restarts the app to initialize callbacks.
+/// Callback for user login. Initialize callbacks when the user is active on this account again
+/// Start listeners istead of calling 'scheduleRestart' because it would fail to unregister them
 - (void)receiveBecomeActiveNote:(NSNotification*)note
 {
   NSLog(@"User logged back in, restarting...");
   loggedOut = false;
+  // If we try to restart instead of just plainly subscribe, the app crashes
+  // At the 'unregisterMTDeviceCallback MTDeviceRelease(device);'
+  // Seems like it can't find the device to unsub from
   [self startUnstableListeners];
 }
 


### PR DESCRIPTION
Subscribe to [SessionDidResignActiveNotification](https://developer.apple.com/documentation/appkit/nsworkspacesessiondidresignactivenotification) and `SessionDidBecomeActive` to kill and resurrect touch callbacks

⚠️ This is my first try at Obj-C, beware ⚠️

# Steps to reproduce
* Switch to another user (*lock screen doesn't cause the app to pause*)
* In Firefox with enabled `General -> Browsing -> Use autoscrolling` use middle click
* Even if second user doesn't have the app running, it would click at the coordinates where the mouse was before the first user logged out

> Hopefully with this fix it won't do that anymore :)

# To be aware
* Tested with 2 users both running the app from `/Applications`, not `/Users/<user>/Applications`. Seems to work fine, but console log is a bit sussy:
<details>
<summary>Multiple `Display reconfigured` calls right before login that schedule a restart AFTER the app has just got mouse listeners from the `BecomeActiveNotification`</summary>

```
default	14:06:34.762468+0000	MiddleClick	HIDAnalytics Set Value Send event com.apple.iokituser.hid.iohidpostevent
default	14:06:34.762535+0000	MiddleClick	HIDAnalytics Unregister Send event com.apple.iokituser.hid.iohidpostevent
default	14:07:07.024424+0000	MiddleClick	Display reconfigured, restarting...
default	14:07:07.024468+0000	MiddleClick	Display reconfigured, restarting...
default	14:07:07.157756+0000	MiddleClick	User logged out, stopping...
default	14:07:07.157826+0000	MiddleClick	Stopping unstable listeners...
default	14:07:09.025388+0000	MiddleClick	User is logged out, abort restart...
default	14:07:09.204876+0000	MiddleClick	Restarting app functionality...
default	14:07:09.204957+0000	MiddleClick	Stopping unstable listeners...
default	14:07:09.206677+0000	MiddleClick	Starting unstable listeners...
default	14:07:20.765225+0000	MiddleClick	Display reconfigured, restarting...
default	14:07:20.765295+0000	MiddleClick	Display reconfigured, restarting...
default	14:07:20.922754+0000	MiddleClick	Display reconfigured, restarting...
default	14:07:20.922790+0000	MiddleClick	Display reconfigured, restarting...
default	14:07:21.062414+0000	MiddleClick	User logged back in, restarting...
default	14:07:21.062483+0000	MiddleClick	Starting unstable listeners...
default	14:07:22.766397+0000	MiddleClick	User is logged out, abort restart...
default	14:07:22.923851+0000	MiddleClick	Restarting app functionality...
default	14:07:22.924016+0000	MiddleClick	Stopping unstable listeners...
default	14:07:22.955471+0000	MiddleClick	Starting unstable listeners...

```
</details>

* May-or-may-not (I have no idea) cause mac to basically stop responding

I was testing, second user was logging in (*initiated the switch with the fingerprint scanner*) and it just didn't log in the second profile. Only showed lock screen with the spinning symbol (*not beachball*) instead of password field

Additionally I tried clicking on the first user again and typed the password - same thing, just a spinner and no progress

Maybe it is caused by some race condition from the previous log and I happened to switch too fast between them, but I really have no idea