### PR TITLE
Option to ignore specific apps

### DIFF
--- a/MiddleClick/Controller.m
+++ b/MiddleClick/Controller.m
@@ -369,6 +369,8 @@ static BOOL isIgnoredAppBundle(CGPoint point) {
 
   NSInteger windowNumber = [NSWindow windowNumberAtPoint:point belowWindowWithWindowNumber:0];
 
+  bool ignored = false;
+
   CFArrayRef windows = CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly, kCGNullWindowID);
   for (NSDictionary* window in (__bridge NSArray*)windows) {
     if ([window[(NSString*)kCGWindowNumber] integerValue] == windowNumber) {
@@ -377,12 +379,14 @@ static BOOL isIgnoredAppBundle(CGPoint point) {
 
       NSString* appBundle = [app bundleIdentifier];
       if ([ignoredAppBundles containsObject:appBundle]) {
-        return true;
+        ignored = true;
+        break;
       }
     }
   }
 
-  return false;
+  CFRelease(windows);
+  return ignored;
 }
 
 /// Callback when a multitouch device is added.

--- a/MiddleClick/Controller.m
+++ b/MiddleClick/Controller.m
@@ -367,6 +367,8 @@ static BOOL isIgnoredAppBundle(CGPoint point) {
     return false;
   }
 
+  point.y = [[NSScreen mainScreen] frame].size.height - point.y;
+
   NSInteger windowNumber = [NSWindow windowNumberAtPoint:point belowWindowWithWindowNumber:0];
 
   bool ignored = false;

--- a/MiddleClick/Controller.m
+++ b/MiddleClick/Controller.m
@@ -380,8 +380,9 @@ static BOOL isIgnoredAppBundle(CGPoint point) {
       NSString* appBundle = [app bundleIdentifier];
       if ([ignoredAppBundles containsObject:appBundle]) {
         ignored = true;
-        break;
       }
+
+      break;
     }
   }
 

--- a/MiddleClick/PreferenceKeys.h
+++ b/MiddleClick/PreferenceKeys.h
@@ -10,3 +10,7 @@
 // The maximum interval in milliseconds between touch and release for a tap to be considered valid.
 #define kMaxTimeDeltaMs @"maxTimeDelta"
 #define kMaxTimeDeltaMsDefault 300
+
+// List of applications that should be ignored
+#define kIgnoredAppBundles @"ignoredAppBundles"
+#define kIgnoredAppBundlesDefault [NSArray array]

--- a/MiddleClick/main.m
+++ b/MiddleClick/main.m
@@ -8,11 +8,13 @@ int main(int argc, char* argv[])
     kFingersNum,
     kMaxDistanceDelta,
     kMaxTimeDeltaMs,
+    kIgnoredAppBundles
   };
   id objects[] = {
     [NSNumber numberWithInt:kFingersNumDefault],
     [NSNumber numberWithFloat:kMaxDistanceDeltaDefault],
     [NSNumber numberWithInt:kMaxTimeDeltaMsDefault],
+    [NSArray arrayWithArray:kIgnoredAppBundlesDefault]
   };
   NSUInteger count = sizeof(objects) / sizeof(id);
   NSDictionary *appDefaults = [NSDictionary

--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ defaults write com.rouge41.middleClick maxTimeDelta 150
 
 > Default is 300
 
+### Ignoring certain applications
+
+- You can disable MiddleClick for certain app windows by providing a list of app bundles to ignore
+
+```ps1
+defaults write com.rouge41.middleClick ignoredAppBundles -array com.microsoft.rdc.macos com.apple.Terminal
+```
+
 ---
 
 <details>


### PR DESCRIPTION
This PR adds the ability to not send middle clicks to specific applications. 

This can resolve #90, as well as issues in any other apps where it might not be beneficial to send middle click events. For example, Microsoft Remote Desktop will send a middle click on a three finger tap when connected to a remote machine, which can cause a double middle click.

This works by adding a new Defaults key containing an array of app bundle identifiers to ignore: 
```ps1
defaults write com.rouge41.middleClick ignoredAppBundles -array com.microsoft.rdc.macos com.apple.Terminal
```