### PR TITLE
fix small typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It's more than just `⌘`+click
 
 <p align="right">
 
-`In Safari` · middleclicking on a link opens it in background
+`In Safari` · middleclicking on a link opens it in the background as a new tab
 
 </p>
 


### PR DESCRIPTION
goes from:
middleclicking on a link opens it in background
to:
middleclicking on a link opens it in the background as a new tab

I feel this a bit clearer as it gives more information, and also makes grammatical sense.